### PR TITLE
Add Access implementation

### DIFF
--- a/src/Access/Access.sol
+++ b/src/Access/Access.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {AccessControl} from "lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
+import {Ownable2Step} from "lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol";
+import {SetUp} from "src/SetUp.sol";
+
+contract Access is Ownable2Step, AccessControl, SetUp {
+    bytes32 public constant ADMIN_ROLE = keccak256(abi.encodePacked("ADMIN"));
+
+    function hasRole(bytes32 role, address account) public view override returns (bool) {
+        // owns role, owns admin role, or is owner
+        return super.hasRole(role, account) || hasAdminRole(role, account) || account == owner();
+    }
+
+    function hasAdminRole(bytes32 role, address account) public view returns (bool) {
+        return super.hasRole(getRoleAdmin(role), account);
+    }
+
+    function getRoleAdmin(bytes32 role) public view override returns (bytes32) {
+        bytes32 adminRole = super.getRoleAdmin(role);
+        return adminRole == bytes32(0x0) ? ADMIN_ROLE : adminRole;
+    }
+
+    function grantRoleAndSetUp(bytes32 role, address account, bytes calldata data) external {
+        grantRole(role, account);
+        _setUp(account, data);
+    }
+
+    function hashRole(string memory role) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(role));
+    }
+}

--- a/src/Access/Access.sol
+++ b/src/Access/Access.sol
@@ -9,12 +9,8 @@ contract Access is Ownable2Step, AccessControl, SetUp {
     bytes32 public constant ADMIN_ROLE = keccak256(abi.encodePacked("ADMIN"));
 
     function hasRole(bytes32 role, address account) public view override returns (bool) {
-        // owns role, owns admin role, or is owner
-        return super.hasRole(role, account) || hasAdminRole(role, account) || account == owner();
-    }
-
-    function hasAdminRole(bytes32 role, address account) public view returns (bool) {
-        return super.hasRole(getRoleAdmin(role), account);
+        // has role, has admin role, or is owner
+        return super.hasRole(role, account) || super.hasRole(getRoleAdmin(role), account) || account == owner();
     }
 
     function getRoleAdmin(bytes32 role) public view override returns (bytes32) {

--- a/src/Access/README.md
+++ b/src/Access/README.md
@@ -1,0 +1,19 @@
+# Access
+
+Opinionated access layer for extensible role systems and multi-tiered management.
+
+Inherits [AccessControl](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/AccessControl.sol) and [Ownable2Step](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable2Step.sol).
+
+## Design decisions
+
+### 1. 3-tier role system: Roles, Admins, Owner
+
+For someone to have access to an operation, they must either hold the role corresponding to that operation, be an admin of the role, or be an owner of the contract. While admins are included in the native `AccessControl`, this implementation grants admins their controlled roles automatically. This simplifies patterns of giving administrative access to someone once that enables them to do many things. Because admins are allowed to edit each other, a singular owner is still used for the top-most control over a contract. The same convenience of auto-granting all controlled roles to admins is also extended to the owner.
+
+### 2. 2-step owner transfers
+
+While optional, a 2-step process for `owner` transfer is enabled and recommended given the high-severity if accidentally transferred to an incorrect address.
+
+### 3. Additional setup on granted accounts `(optional)`
+
+When granting roles to other smart contracts, it can be useful to also call them to initialize some parameters needed for proper operation. There is an additional `grantRoleAndSetUp(bytes32 role, address account, bytes calldata data)` function for this added convenience for granting with atomicity guarantees on an account's setup.

--- a/src/Access/README.md
+++ b/src/Access/README.md
@@ -12,7 +12,7 @@ For someone to have access to an operation, they must either hold the role corre
 
 ### 2. 2-step owner transfers
 
-While optional, a 2-step process for `owner` transfer is enabled and recommended given the high-severity if accidentally transferred to an incorrect address.
+While optional, a 2-step process for `owner` transfer is enabled and recommended given the high-severity if accidentally transferred to an incorrect address. First the current owner must publish the next owner and then this pending owner must accept the transfer to complete the process.
 
 ### 3. Additional setup on granted accounts `(optional)`
 

--- a/src/SetUp.sol
+++ b/src/SetUp.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+abstract contract SetUp {
+    error SetUpFailed(address account, bytes data);
+
+    function _setUp(address account, bytes calldata data) internal {
+        (bool success, bytes memory res) = account.call(data);
+        if (!success) revert SetUpFailed(account, res);
+    }
+}


### PR DESCRIPTION
# Access

Opinionated access layer for extensible role systems and multi-tiered management.

Inherits [AccessControl](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/AccessControl.sol) and [Ownable2Step](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable2Step.sol).

## Design decisions

### 1. 3-tier role system: Roles, Admins, Owner

For someone to have access to an operation, they must either hold the role corresponding to that operation, be an admin of the role, or be an owner of the contract. While admins are included in the native `AccessControl`, this implementation grants admins their controlled roles automatically. This simplifies patterns of giving administrative access to someone once that enables them to do many things. Because admins are allowed to edit each other, a singular owner is still used for the top-most control over a contract. The same convenience of auto-granting all controlled roles to admins is also extended to the owner.

### 2. 2-step owner transfers

While optional, a 2-step process for `owner` transfer is enabled and recommended given the high-severity if accidentally transferred to an incorrect address. First the current owner must publish the next owner and then this pending owner must accept the transfer to complete the process.

### 3. Additional setup on granted accounts `(optional)`

When granting roles to other smart contracts, it can be useful to also call them to initialize some parameters needed for proper operation. There is an additional `grantRoleAndSetUp(bytes32 role, address account, bytes calldata data)` function for this added convenience for granting with atomicity guarantees on an account's setup.