### PR TITLE
Add Extensions

### DIFF
--- a/src/Extensions/BaseExtensionRouter.sol
+++ b/src/Extensions/BaseExtensionRouter.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IBaseExtensionRouter} from "./interface/IBaseExtensionRouter.sol";
+import {IExtension} from "./interface/IExtension.sol";
+import {Address} from "lib/openzeppelin-contracts/contracts/utils/Address.sol";
+
+abstract contract BaseExtensionRouter is IBaseExtensionRouter {
+    Extension[] internal _extensions;
+    mapping(bytes4 => Extension) internal _selectors;
+
+    /*==================
+        CALL ROUTING
+    ==================*/
+
+    fallback() external payable virtual {
+        address implementation = extensionOf(msg.sig);
+        _delegate(implementation);
+    }
+
+    receive() external payable virtual {}
+
+    /// @dev delegateCalls an `implementation` smart contract.
+    function _delegate(address implementation) internal virtual {
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    /*===========
+        VIEWS
+    ===========*/
+
+    function hasExtended(bytes4 selector) public view virtual returns (bool) {
+        return _selectors[selector].implementation != address(0);
+    }
+
+    function extensionOf(bytes4 selector) public view virtual returns (address implementation) {
+        return extensionOf(selector, 2 ** 40 - 1); // max uint40
+    }
+
+    function extensionOf(bytes4 selector, uint40 updatedAtThreshold)
+        public
+        view
+        virtual
+        returns (address implementation)
+    {
+        Extension memory extension = _selectors[selector];
+        if (extension.implementation == address(0)) revert SelectorNotExtended(selector);
+        if (extension.updatedAt > updatedAtThreshold) {
+            revert ExtensionUpdatedAfter(selector, extension.updatedAt, updatedAtThreshold);
+        }
+        return extension.implementation;
+    }
+
+    function getAllExtensions() public view virtual returns (ExtensionWithSignature[] memory extensions) {
+        uint256 len = _extensions.length;
+        extensions = new ExtensionWithSignature[](len);
+        for (uint256 i; i < len; i++) {
+            Extension memory extension = _extensions[i + 1];
+            extensions[i] = ExtensionWithSignature(
+                extension.selector,
+                extension.implementation,
+                IExtension(extension.implementation).signatureOf(extension.selector)
+            );
+        }
+        return extensions;
+    }
+
+    /*=============
+        SETTERS
+    =============*/
+
+    modifier canExtend() {
+        if (!_canExtend(msg.sender)) revert UnauthorizedToExtend(msg.sender);
+        _;
+    }
+
+    function addExtension(bytes4 selector, address implementation) public canExtend {
+        _addExtension(selector, implementation);
+    }
+
+    function removeExtension(bytes4 selector) public canExtend {
+        _removeExtension(selector);
+    }
+
+    function updateExtension(bytes4 selector, address implementation) public canExtend {
+        _updateExtension(selector, implementation);
+    }
+
+    /*===============
+        INTERNALS
+    ===============*/
+
+    function _addExtension(bytes4 selector, address implementation) internal {
+        if (!Address.isContract(implementation)) revert InvalidContract(implementation);
+        Extension memory oldExtension = _selectors[selector];
+        if (oldExtension.implementation != address(0)) revert SelectorAlreadyExtended(selector);
+
+        Extension memory extension =
+            Extension(selector, implementation, uint24(_extensions.length), uint40(block.timestamp)); // new length will be `len + 1`, so this extension has index `len`
+
+        _selectors[selector] = extension;
+        _extensions.push(extension); // set new extension at index and increment length
+
+        emit Extend(selector, address(0), implementation);
+    }
+
+    function _removeExtension(bytes4 selector) internal {
+        Extension memory oldExtension = _selectors[selector];
+        if (oldExtension.implementation == address(0)) revert SelectorNotExtended(selector);
+
+        uint256 lastIndex = _extensions.length - 1;
+        // if removing extension not at the end of the array, swap extension with last in array
+        if (oldExtension.index < lastIndex) {
+            Extension memory lastExtension = _extensions[lastIndex];
+            lastExtension.index = oldExtension.index;
+            _selectors[lastExtension.selector] = lastExtension;
+            _extensions[oldExtension.index] = lastExtension;
+        }
+        delete _selectors[selector];
+        _extensions.pop(); // delete extension in last index and decrement length
+
+        emit Extend(selector, oldExtension.implementation, address(0));
+    }
+
+    function _updateExtension(bytes4 selector, address implementation) internal {
+        require(Address.isContract(implementation));
+        Extension memory oldExtension = _selectors[selector];
+        if (implementation == oldExtension.implementation) {
+            revert ExtensionUnchanged(oldExtension.implementation, implementation);
+        }
+
+        Extension memory newExtension =
+            Extension(selector, implementation, uint24(oldExtension.index), uint40(block.timestamp));
+        _selectors[selector] = newExtension;
+        _extensions[oldExtension.index] = newExtension; // directly update index to leave _extensions.length unchanged
+
+        emit Extend(selector, oldExtension.implementation, implementation);
+    }
+
+    /*===================
+        AUTHORIZATION
+    ===================*/
+
+    function _canExtend(address operator) internal virtual returns (bool) {}
+}

--- a/src/Extensions/Extension.sol
+++ b/src/Extensions/Extension.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IExtension} from "./interface/IExtension.sol";
+
+abstract contract Extension is IExtension {
+    constructor() {
+        getAllSignatures(); // verify selectors properly synced
+    }
+
+    function contractURI() external view virtual returns (string memory uri) {}
+    function signatureOf(bytes4 selector) public pure virtual returns (string memory signature) {}
+    function getAllSelectors() public pure virtual returns (bytes4[] memory selectors) {}
+
+    function getAllSignatures() public pure returns (string[] memory signatures) {
+        bytes4[] memory selectors = getAllSelectors();
+        uint256 len = selectors.length;
+        signatures = new string[](len);
+        for (uint256 i; i < len; i++) {
+            bytes4 selector = selectors[i];
+            string memory signature = signatureOf(selector);
+            require(bytes4(keccak256(abi.encodePacked(signature))) == selector, "SELECTOR_SIGNATURE_MISMATCH");
+            signatures[i] = signature;
+        }
+    }
+}

--- a/src/Extensions/ExtensionRouter.sol
+++ b/src/Extensions/ExtensionRouter.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {BaseExtensionRouter} from "./BaseExtensionRouter.sol";
+import {IBaseExtensionRouter} from "./interface/IBaseExtensionRouter.sol";
+import {IExtensionRouter} from "./interface/IExtensionRouter.sol";
+import {IExtension} from "./interface/IExtension.sol";
+
+abstract contract ExtensionRouter is BaseExtensionRouter, IExtensionRouter {
+    struct ExtensionBeacon {
+        address router;
+        uint40 lastValidUpdatedAt;
+    }
+
+    ExtensionBeacon internal extensionBeacon;
+
+    /*===========
+        VIEWS
+    ===========*/
+
+    function extensionOf(bytes4 selector) public view override returns (address implementation) {
+        implementation = super.extensionOf(selector);
+        if (implementation != address(0)) return implementation;
+
+        // no local implementation, fetch from beacon
+        ExtensionBeacon memory beacon = extensionBeacon;
+        if (beacon.router == address(0)) revert SelectorNotExtended(selector);
+        implementation = IBaseExtensionRouter(beacon.router).extensionOf(selector, beacon.lastValidUpdatedAt);
+        if (implementation == address(0)) revert SelectorNotExtended(selector);
+
+        return implementation;
+    }
+
+    function getAllExtensions() public view override returns (ExtensionWithSignature[] memory extensions) {
+        ExtensionWithSignature[] memory beaconExtensions =
+            IBaseExtensionRouter(extensionBeacon.router).getAllExtensions();
+        ExtensionWithSignature[] memory localExtensions = super.getAllExtensions();
+        uint256 lenBeacon = beaconExtensions.length;
+        uint256 lenLocal = localExtensions.length;
+
+        // calculate number of overriden selectors
+        uint256 numOverrides;
+        for (uint256 i; i < lenBeacon; i++) {
+            if (hasExtended(beaconExtensions[i].selector)) {
+                numOverrides++;
+            }
+        }
+        // create new extensions array with total length without overriden selectors
+        uint256 lenTotal = lenLocal + lenBeacon - numOverrides;
+        extensions = new ExtensionWithSignature[](lenTotal);
+        // add non-overriden beacon extensions to return
+        uint256 j;
+        for (uint256 i; i < lenBeacon; i++) {
+            if (!hasExtended(beaconExtensions[i].selector)) {
+                extensions[j] = beaconExtensions[i];
+                j++;
+            }
+        }
+        // add local extensions to return
+        for (uint256 i; i < lenLocal; i++) {
+            extensions[j] = localExtensions[i];
+            j++;
+        }
+
+        return extensions;
+    }
+
+    /*=============
+        SETTERS
+    =============*/
+
+    function removeExtensionBeacon() public virtual canExtend {
+        _updateExtensionBeacon(address(0), 0);
+    }
+
+    function refreshExtensionBeacon(uint40 lastValidUpdatedAt) public virtual canExtend {
+        address oldBeacon = extensionBeacon.router;
+        _updateExtensionBeacon(oldBeacon, lastValidUpdatedAt);
+    }
+
+    function setExtensionBeacon(address newBeacon, uint40 lastValidUpdatedAt) public virtual canExtend {
+        require(newBeacon != address(0));
+        require(lastValidUpdatedAt > 0);
+        _updateExtensionBeacon(newBeacon, lastValidUpdatedAt);
+    }
+
+    /*===============
+        INTERNALS
+    ===============*/
+
+    function _updateExtensionBeacon(address newBeacon, uint40 lastValidUpdatedAt) internal {
+        address oldBeacon = extensionBeacon.router;
+        extensionBeacon = ExtensionBeacon(newBeacon, lastValidUpdatedAt);
+        emit ExtensionBeaconUpdated(oldBeacon, newBeacon, lastValidUpdatedAt);
+    }
+}

--- a/src/Extensions/README.md
+++ b/src/Extensions/README.md
@@ -2,7 +2,7 @@
 
 Generalized extension layer for modularizing fallback behavior.
 
-Inspired by Diamond Proxies/ERC-2535 and Thirdweb's [Dynamic Contracts Standard](https://github.com/thirdweb-dev/dynamic-contracts/tree/main)
+Inspired by [ERC-2535](https://eips.ethereum.org/EIPS/eip-2535) and Thirdweb's [Dynamic Contracts](https://github.com/thirdweb-dev/dynamic-contracts/tree/main).
 
 ## Design decisions
 
@@ -12,7 +12,7 @@ Inspired by Diamond Proxies/ERC-2535 and Thirdweb's [Dynamic Contracts Standard]
 
 ### 1. Lean implementation
 
-[ERC-2535 Diamonds](https://eips.ethereum.org/EIPS/eip-2535) are the source inspiration for Thirdweb's [Dynamic Contracts](https://github.com/thirdweb-dev/dynamic-contracts/tree/main) which was the main reference point for this prototype. While Thirdweb's implementation is an attempt at diamond's "leanest, simplest form", I believe there is still more unnecessary weight to shed.
+ERC-2535 pioneered a new pattern for upgradeable contracts, but is also quite heavy and complex. Thirdweb's Dynamic Contracts is an attempt to implement diamond in their "leanest, simplest form" and improve the developer experience. I believe there is still more unnecessary weight to shed.
 
 The most fundamental idea of the diamond pattern is that a diamond will route inbound calls to different implementation contracts, facets, and determines the appropriate facet to use via a mapping of function selectors to addresses. Anything beyond the singular `mapping(bytes4 => address) facets` storage and functions to support reading and writing to it is non-essential.
 
@@ -34,4 +34,4 @@ When designing a beacon, it's important to enable followers to protect themselve
 
 ## Examples
 
-- [MetadataExtension](./examples/MetadataExtension.sol): Only allow operations within a defined time window.
+- [MetadataRouterExtension](./examples/MetadataRouterExtension.sol): Modularize a `tokenURI` function by routing calls through another contract.

--- a/src/Extensions/README.md
+++ b/src/Extensions/README.md
@@ -1,0 +1,37 @@
+# Extensions
+
+Generalized extension layer for modularizing fallback behavior.
+
+Inspired by Diamond Proxies/ERC-2535 and Thirdweb's [Dynamic Contracts Standard](https://github.com/thirdweb-dev/dynamic-contracts/tree/main)
+
+## Design decisions
+
+- minimal storage: signatures on extensions, no functionsOfExtension method
+- optimized storage: pack index into struct
+- beacon routing by default with timestamping selectors protection mechanism
+
+### 1. Lean implementation
+
+[ERC-2535 Diamonds](https://eips.ethereum.org/EIPS/eip-2535) are the source inspiration for Thirdweb's [Dynamic Contracts](https://github.com/thirdweb-dev/dynamic-contracts/tree/main) which was the main reference point for this prototype. While Thirdweb's implementation is an attempt at diamond's "leanest, simplest form", I believe there is still more unnecessary weight to shed.
+
+The most fundamental idea of the diamond pattern is that a diamond will route inbound calls to different implementation contracts, facets, and determines the appropriate facet to use via a mapping of function selectors to addresses. Anything beyond the singular `mapping(bytes4 => address) facets` storage and functions to support reading and writing to it is non-essential.
+
+Layers of functionality beyond this have the goal of enhancing the developer experience and this is where our prototype diverges from ERC-2535 and Thirdweb by being more minimal. Our implementation only cares about a view function to get all of the extended selectors and their implementations on the diamond. We do not care about storing names of extensions, metadata URIs, function signatures, or even enabled facets. We do this primarily to save a **lot** of gas by not storing data that is non-essential to execution.
+
+We still don't sacrifice on developer convenience of accessing metadata, but we do re-allocate most of its responsibility to extension deployers. Every extension defines its own metadata once at deployment to be shared by all consumers of it.
+
+### 2. Optimized storage
+
+Stripping out most of the non-essential functionality provided in other standards removes a lot of storage. In addition to struct-packing our state, we optimize further by rewriting enumeration patterns.
+
+To support our convenience function of returning all extended selectors, we need to introduce a means to enumerate all of the selectors and their mapped extensions on a diamond. Typical implementations inherit something like Open Zeppelin's [EnumerableSet](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol), but this adds a noticeable overhead when adding, updating, and removing extensions. Drawing from the underlying patterns of making an enumerable set, we embed the same information requirements in our existing storage to save 30% on these operations.
+
+### 3. Beacon routing with time-based versioning protection
+
+The basics of extension management and call routing are handled by `BaseExtensionRouter` and is perfectly viable to import directly into your individual use cases. In cases where you want to build a platform that helps other people create contracts for their use case, the `ExtensionRouter` is recommended for its additional beacon pattern. Taking inspiration from beacon proxies, an extension beacon is a contract that many other contracts point to for extension implementation addresses. The pattern helps one team update extensions on one beacon that immediately apply to all contracts following it. Individual contracts first check their own local storage for an extension of a selector, but refer to a beacon for default implementations otherwise.
+
+When designing a beacon, it's important to enable followers to protect themselves from mismanagement. When you follow a beacon, you also store a timestamp that you trust the state of the beacon up until. This means extension additions and updates on the beacon made after your timestamp will not be considered part of your implementation. This additional security feature is optional and you can increase your risk but reduce operational overhead by setting your timestamp to the maximum `uint40`, effectively pre-approving all future changes to the beacon for use in your contract.
+
+## Examples
+
+- [MetadataExtension](./examples/MetadataExtension.sol): Only allow operations within a defined time window.

--- a/src/Extensions/examples/MetadataRouterExtension.sol
+++ b/src/Extensions/examples/MetadataRouterExtension.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Extension} from "../Extension.sol";
+
+library MetadataRouterStorage {
+    bytes32 public constant STORAGE_POSITION = keccak256("extensions.mage.metadataRouter.storage");
+
+    struct Data {
+        address metadataRouter;
+    }
+
+    function read() internal pure returns (Data storage data) {
+        bytes32 position = STORAGE_POSITION;
+        assembly {
+            data.slot := position
+        }
+    }
+}
+
+interface IMetadataRouter {
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}
+
+contract MetadataRouterExtension is Extension {
+    /*===============
+        EXTENSION
+    ===============*/
+
+    function getAllSelectors() public pure override returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = this.tokenURI.selector;
+        return selectors;
+    }
+
+    function signatureOf(bytes4 selector) public pure override returns (string memory) {
+        if (selector == this.tokenURI.selector) {
+            return "tokenURI(uint256)";
+        } else {
+            return "";
+        }
+    }
+
+    function contractURI() external pure override returns (string memory uri) {
+        return "";
+    }
+
+    /*===============
+        FUNCTIONS
+    ===============*/
+
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        return IMetadataRouter(_getMetadataRouter()).tokenURI(tokenId);
+    }
+
+    /*===============
+        INTERNALS
+    ===============*/
+
+    function _getMetadataRouter() internal view returns (address) {
+        MetadataRouterStorage.Data storage data = MetadataRouterStorage.read();
+        return data.metadataRouter;
+    }
+}

--- a/src/Extensions/examples/MetadataRouterExtension.sol
+++ b/src/Extensions/examples/MetadataRouterExtension.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import {Extension} from "../Extension.sol";
 
 library MetadataRouterStorage {
-    bytes32 public constant STORAGE_POSITION = keccak256("extensions.mage.metadataRouter.storage");
+    bytes32 public constant STORAGE_POSITION = keccak256("extensions.metadataRouter.storage");
 
     struct Data {
         address metadataRouter;

--- a/src/Extensions/interface/IBaseExtensionRouter.sol
+++ b/src/Extensions/interface/IBaseExtensionRouter.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IBaseExtensionRouter {
+    struct Extension {
+        bytes4 selector; // 32 bits
+        address implementation; // 160 bits
+        uint24 index; // 24 bits
+        uint40 updatedAt; // 40 bits
+    }
+
+    struct ExtensionWithSignature {
+        bytes4 selector;
+        address implementation;
+        string signature;
+    }
+
+    event Extend(bytes4 indexed selector, address indexed oldExtension, address indexed newExtension);
+
+    error UnauthorizedToExtend(address operator);
+    error SelectorNotExtended(bytes4 selector);
+    error SelectorAlreadyExtended(bytes4 selector);
+    error InvalidContract(address implementation);
+    error ExtensionUnchanged(address oldImplementation, address newImplementation);
+    error ExtensionUpdatedAfter(bytes4 selector, uint40 updatedAt, uint40 updateThreshold);
+
+    function extensionOf(bytes4 selector) external view returns (address implementation);
+    function extensionOf(bytes4 selector, uint40 updatedBefore) external view returns (address implementation);
+    function getAllExtensions() external view returns (ExtensionWithSignature[] memory extensions);
+    function addExtension(bytes4 selector, address implementation) external;
+    function removeExtension(bytes4 selector) external;
+    function updateExtension(bytes4 selector, address implementation) external;
+}

--- a/src/Extensions/interface/IExtension.sol
+++ b/src/Extensions/interface/IExtension.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IExtension {
+    function contractURI() external view returns (string memory);
+    function signatureOf(bytes4 selector) external pure returns (string memory signature);
+    function getAllSelectors() external pure returns (bytes4[] memory selectors);
+    function getAllSignatures() external pure returns (string[] memory signatures);
+}

--- a/src/Extensions/interface/IExtensionRouter.sol
+++ b/src/Extensions/interface/IExtensionRouter.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IExtensionRouter {
+    event ExtensionBeaconUpdated(address indexed oldBeacon, address indexed newBeacon, uint40 lastValidUpdatedAt);
+
+    function updateExtensionBeacon(address newBeacon, uint40 lastValidUpdatedAt) external;
+}


### PR DESCRIPTION
# Extensions

Generalized extension layer for modularizing fallback behavior.

Inspired by [ERC-2535](https://eips.ethereum.org/EIPS/eip-2535) and Thirdweb's [Dynamic Contracts](https://github.com/thirdweb-dev/dynamic-contracts/tree/main).

## Design decisions

- minimal storage: signatures on extensions, no functionsOfExtension method
- optimized storage: pack index into struct
- beacon routing by default with timestamping selectors protection mechanism

### 1. Lean implementation

ERC-2535 pioneered a new pattern for upgradeable contracts, but is also quite heavy and complex. Thirdweb's Dynamic Contracts is an attempt to implement diamond in their "leanest, simplest form" and improve the developer experience. I believe there is still more unnecessary weight to shed.

The most fundamental idea of the diamond pattern is that a diamond will route inbound calls to different implementation contracts, facets, and determines the appropriate facet to use via a mapping of function selectors to addresses. Anything beyond the singular `mapping(bytes4 => address) facets` storage and functions to support reading and writing to it is non-essential.

Layers of functionality beyond this have the goal of enhancing the developer experience and this is where our prototype diverges from ERC-2535 and Thirdweb by being more minimal. Our implementation only cares about a view function to get all of the extended selectors and their implementations on the diamond. We do not care about storing names of extensions, metadata URIs, function signatures, or even enabled facets. We do this primarily to save a **lot** of gas by not storing data that is non-essential to execution.

We still don't sacrifice on developer convenience of accessing metadata, but we do re-allocate most of its responsibility to extension deployers. Every extension defines its own metadata once at deployment to be shared by all consumers of it.

### 2. Optimized storage

Stripping out most of the non-essential functionality provided in other standards removes a lot of storage. In addition to struct-packing our state, we optimize further by rewriting enumeration patterns.

To support our convenience function of returning all extended selectors, we need to introduce a means to enumerate all of the selectors and their mapped extensions on a diamond. Typical implementations inherit something like Open Zeppelin's [EnumerableSet](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol), but this adds a noticeable overhead when adding, updating, and removing extensions. Drawing from the underlying patterns of making an enumerable set, we embed the same information requirements in our existing storage to save 30% on these operations.

### 3. Beacon routing with time-based versioning protection

The basics of extension management and call routing are handled by `BaseExtensionRouter` and is perfectly viable to import directly into your individual use cases. In cases where you want to build a platform that helps other people create contracts for their use case, the `ExtensionRouter` is recommended for its additional beacon pattern. Taking inspiration from beacon proxies, an extension beacon is a contract that many other contracts point to for extension implementation addresses. The pattern helps one team update extensions on one beacon that immediately apply to all contracts following it. Individual contracts first check their own local storage for an extension of a selector, but refer to a beacon for default implementations otherwise.

When designing a beacon, it's important to enable followers to protect themselves from mismanagement. When you follow a beacon, you also store a timestamp that you trust the state of the beacon up until. This means extension additions and updates on the beacon made after your timestamp will not be considered part of your implementation. This additional security feature is optional and you can increase your risk but reduce operational overhead by setting your timestamp to the maximum `uint40`, effectively pre-approving all future changes to the beacon for use in your contract.

## Examples

- [MetadataRouterExtension](./examples/MetadataRouterExtension.sol): Modularize a `tokenURI` function by routing calls through another contract.